### PR TITLE
Prevent sharding start error

### DIFF
--- a/Bot Sharder/sharded-bot.js
+++ b/Bot Sharder/sharded-bot.js
@@ -97,4 +97,4 @@ const manager = new ShardingManager(startup, {
 
 manager.on('shardCreate', (shard) => console.log(`Shard ${shard.id} launched`));
 
-manager.spawn();
+manager.spawn(Number(totalShards), 5500, -1); 

--- a/Bot Sharder/sharded-bot.js
+++ b/Bot Sharder/sharded-bot.js
@@ -97,4 +97,4 @@ const manager = new ShardingManager(startup, {
 
 manager.on('shardCreate', (shard) => console.log(`Shard ${shard.id} launched`));
 
-manager.spawn(Number(totalShards), 5500, -1); 
+manager.spawn(totalShards, 5500, -1); 


### PR DESCRIPTION
Sometimes some people may get this error when trying to start their sharded bot:
```shell
Error [SHARDING_READY_TIMEOUT]: Shard 0's Client took too long to become ready.?
```
This can be caused by a shard being in unavailable guilds, which completely stop bots from connecting.

In order to prevent this and future errors from happening to anyone the spawnTimeout can be set to -1 or Infinity: [more info](https://discord.js.org/#/docs/main/stable/class/ShardingManager?scrollTo=spawn)

* Prevent unavailable guilds from not letting a shard start
* Prevents a few other problems aswell